### PR TITLE
feat(ai): add OrcaRouter as a named AI provider preset

### DIFF
--- a/src/page/setting/pages/AiProvide.vue
+++ b/src/page/setting/pages/AiProvide.vue
@@ -260,6 +260,11 @@ const providerPresets: Array<{ label: string; baseUrl: string; invitation?: stri
     invitation: 'https://openrouter.ai/?from=es-client'
   },
   {
+    label: 'OrcaRouter',
+    baseUrl: 'https://api.orcarouter.ai/v1',
+    invitation: 'https://www.orcarouter.ai'
+  },
+  {
     label: 'Moonshot (月之暗面)',
     baseUrl: 'https://api.moonshot.cn/v1',
     invitation: 'https://platform.kimi.com/?from=es-client'


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) to the AI provider presets in `AiProvide.vue`, mirroring the existing OpenRouter entry — ES-Client users can now pick OrcaRouter from the provider list instead of typing a custom base URL. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents: like OpenRouter it exposes a provider/model namespace across many models, and adds adaptive routing, failover, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verification:
- `eslint src/page/setting/pages/AiProvide.vue` — clean
- `vue-tsc --noEmit` — no new errors from this change (92 pre-existing on `master`, unrelated files)
- `vite build --mode=web` — succeeds
- Live: `GET /models` via `https://api.orcarouter.ai/v1` → 200, 203 models; chat completion against `orcarouter/free` succeeded

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
